### PR TITLE
Consistently use /srv/radicale in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ services:
     ports: 
       - "8000:8000"
     volumes: 
-      - /tmp/radicale:/var/radicale
+      - /srv/radicale:/var/radicale
 ```
 Environment variables :
 |Variable|Descriptions|

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Environment variables :
 ## Versioning
 Version the changes to your __radicale__ data your changes using __GIT__.
 
-Create a _.gitignore_ file in _srv/radicale/data:
+Create a _.gitignore_ file in _srv/radicale/data_:
 ```
 .Radicale.cache
 .Radicale.lock


### PR DESCRIPTION
In the CLI example above, `/srv/radicale` is used as the data directory on the host. Use the same in the compose file to prevent confusion.