### PR TITLE
Add RADICALE_NO_SYNC option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Environment variables :
 |GIT_EMAIL|Your mail for the git signature|
 |RADICALE_USER|Your radicale user|
 |RADICALE_PASS|The password for your user|
+|RADICALE_NO_SYNC|Set to a non-empty value to prevent dependency synchronization at startup. Dependencies must be installed during the image build.|
+
+For containers without internet access, set `RADICALE_NO_SYNC=1` to use the dependencies installed during the image build without checking for updates at startup.
 
 ## Versioning
 

--- a/root/srv/run-radicale.sh
+++ b/root/srv/run-radicale.sh
@@ -26,4 +26,8 @@ echo "Setup: done"
 echo "Run radicale"
 
 cd /var/radicale
-uv run --directory /srv python -m radicale --config=/var/radicale/config.ini
+if [ -n "$RADICALE_NO_SYNC" ]; then
+    uv run --no-sync --directory /srv python -m radicale --config=/var/radicale/config.ini
+else
+    uv run --directory /srv python -m radicale --config=/var/radicale/config.ini
+fi


### PR DESCRIPTION
## Reason
Since the migration from `pip` to `uv`, the entrypoint uses `uv run`. `uv run` automatically synchronizes the project environment before starting Radicale, which requires access to the package index. As a result, containers without internet access no longer start, even though their dependencies were already installed while building the image.

`RADICALE_NO_SYNC=1` restores the previous behavior by using the dependencies installed during the image build without attempting a startup synchronization.

## Summary
- add `RADICALE_NO_SYNC` to skip uv dependency synchronization at startup
- document the option for containers without internet access
- preserve the current synchronization behavior by default

## Testing
- `sh -n root/srv/run-radicale.sh`
- `git diff --check`
- Docker build succeeded
- container started with and without `RADICALE_NO_SYNC=1` under `--network none`